### PR TITLE
Simplify with oc extract and fixing correct ca.crt for router-mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ envsubst < ./environment-set-up/amq/cert-patches.yaml | oc apply -f - -n ${proje
 
 
 # if you didn't install resource-locker-operator run this (and re-run it every time certificates are renewed)
-oc get secret amq-amqp-tls-secret -o jsonpath='{.data.keystore\.jks}' -n ${project} | base64 -d > /tmp/broker.ks
-oc get secret amq-amqp-tls-secret -o jsonpath='{.data.truststore\.jks}' -n ${project} | base64 -d > /tmp/client.ts
+oc extract secret/amq-amqp-tls-secret --keys=keystore.jks --to - -n ${project}> /tmp/broker.ks
+oc extract secret/amq-amqp-tls-secret --keys=truststore.jks --to - -n ${project} > /tmp/client.ts
 oc set data secret/amq-amqp-tls-secret --from-file=/tmp/broker.ks --from-file=/tmp/client.ts -n ${project}
-oc get secret amq-console-secret -o jsonpath='{.data.keystore\.jks}' -n ${project} | base64 -d > /tmp/broker.ks
-oc get secret amq-console-secret -o jsonpath='{.data.truststore\.jks}' -n ${project} | base64 -d > /tmp/client.ts
+oc extract secret/amq-console-secret --keys=keystore.jks --to - -n ${project} > /tmp/broker.ks
+oc extract secret/amq-console-secret --keys=truststore.jks --to - -n ${project} > /tmp/client.ts
 oc set data secret/amq-console-secret --from-file=/tmp/broker.ks --from-file=/tmp/client.ts -n ${project}
 ```
 
@@ -109,7 +109,7 @@ patching the certs
 envsubst < ./environment-set-up/amq/interconnect-cert-patches.yaml | oc apply -f - -n ${project}
 
 # If you didn't install resource locker, run the following (and every time the certificates are renewed)
-oc get secret amq-amqp-mesh-client-tls-secret -o jsonpath='{.data.ca.crt}' -n ${project} | base64 -d > /tmp/tls.crt
+oc extract secret/amq-amqp-tls-secret --keys=ca.crt --to - -n ${project} > /tmp/tls.crt
 oc set data secret/amq-amqp-mesh-client-tls-secret --from-file=/tmp/tls.crt -n ${project}
 ```
 


### PR DESCRIPTION
Using `oc extract` instead of `oc get --jsonpath | base64 -d`.

Extract ca.crt from amq-amqp-tls-secret instead of amq-amqp-mesh-client-tls-secret for router-mesh.

Signed-off-by: Adler Fleurant <2609856+AdlerFleurant@users.noreply.github.com>